### PR TITLE
add recommended extension / support clangd (#24)

### DIFF
--- a/platformio/debug/process/server.py
+++ b/platformio/debug/process/server.py
@@ -74,7 +74,7 @@ class DebugServerProcess(DebugBaseProcess):
             if server["cwd"]:
                 args.extend(["-s", server["cwd"]])
             args.extend(
-                ["-c", "gdb_port pipe; tcl_port disabled; telnet_port disabled"]
+                ["-c", "gdb port pipe; tcl port disabled; telnet port disabled"]
             )
             args.extend(server["arguments"])
             str_args = " ".join(

--- a/platformio/project/integration/tpls/vscode/.gitignore.tpl
+++ b/platformio/project/integration/tpls/vscode/.gitignore.tpl
@@ -1,5 +1,8 @@
 .pio
+.cache
+.dummy
 .vscode/.browse.c_cpp.db*
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+compile_commands.json

--- a/platformio/project/integration/tpls/vscode/.vscode/extensions.json.tpl
+++ b/platformio/project/integration/tpls/vscode/.vscode/extensions.json.tpl
@@ -2,7 +2,7 @@
 % import os
 % import re
 %
-% recommendations = set(["pioarduino.pioarduino-ide"])
+% recommendations = set(["pioarduino.pioarduino-ide", "Jason2866.esp-decoder"])
 % unwantedRecommendations = set(["ms-vscode.cpptools-extension-pack"])
 % previous_json = os.path.join(project_dir, ".vscode", "extensions.json")
 % if os.path.isfile(previous_json):


### PR DESCRIPTION
* remove telemetry
* no full git clone
* add intelhex as required
* no core packages
* add `rich_click` as pip dependencies
* remove advertisings
* add intelhex as required
* install scons and Pio home from github
* replace "get_core_package_dir" for piohome and pioremote
* Add esp-decoder to VSCode recommendations (#29)
* fix: gdb use actual cmd syntax
* manage VSC extension (#30)