### PR TITLE
Add udev rule for Espressif ESP-PROG 2

### DIFF
--- a/platformio/assets/system/99-platformio-udev.rules
+++ b/platformio/assets/system/99-platformio-udev.rules
@@ -182,5 +182,8 @@ ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2107", MODE="0666", ENV{ID_MM_DEVICE
 # Espressif USB JTAG/serial debug unit
 ATTRS{idVendor}=="303a", ATTRS{idProduct}=="1001", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
 
+# Espressif ESP-PROG 2
+ATTRS{idVendor}=="303a", ATTRS{idProduct}=="1002", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
+
 # Zephyr framework USB CDC-ACM
 ATTRS{idVendor}=="2fe3", ATTRS{idProduct}=="0100", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Espressif ESP-PROG 2 devices. System-level configuration now ensures proper USB device recognition and handling for seamless integration with development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->