### PR TITLE
fix: do not crash when file:// is not found

### DIFF
--- a/platformio/package/manager/_install.py
+++ b/platformio/package/manager/_install.py
@@ -107,6 +107,16 @@ class PackageManagerInstallMixin:
                 ),
             )
 
+        if not pkg:
+            if spec.external and spec.uri and spec.uri.startswith("file://"):
+                self.log.warning(
+                    click.style(
+                        "Warning! Could not install package '%s': path not found, "
+                        "skipping..." % spec.humanize(),
+                        fg="yellow",
+                    )
+                )
+                return None
         if not pkg or not pkg.metadata:
             raise PackageException(
                 "Could not install package '%s' for '%s' system"
@@ -182,9 +192,15 @@ class PackageManagerInstallMixin:
                 _uri = uri[7:]
                 if os.path.isfile(_uri):
                     self.unpack(_uri, tmp_dir)
-                else:
+                elif os.path.isdir(_uri):
                     fs.rmtree(tmp_dir)
                     shutil.copytree(_uri, tmp_dir, symlinks=True)
+                else:
+                    click.secho(
+                        "Warning! Library not found at %s, skipping..." % _uri,
+                        fg="yellow",
+                    )
+                    return None
             elif uri.startswith(("http://", "https://")):
                 dl_path = self.download(uri, checksum)
                 assert os.path.isfile(dl_path)

--- a/platformio/package/manager/_install.py
+++ b/platformio/package/manager/_install.py
@@ -109,13 +109,6 @@ class PackageManagerInstallMixin:
 
         if not pkg:
             if spec.external and spec.uri and spec.uri.startswith("file://"):
-                self.log.warning(
-                    click.style(
-                        "Warning! Could not install package '%s': path not found, "
-                        "skipping..." % spec.humanize(),
-                        fg="yellow",
-                    )
-                )
                 return None
         if not pkg or not pkg.metadata:
             raise PackageException(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of missing external file sources during installation with clear warning messages
  * Installation now gracefully aborts when external package paths cannot be found, preventing subsequent validation errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->